### PR TITLE
Reverse-play sequences reset correctly

### DIFF
--- a/quence.lua
+++ b/quence.lua
@@ -749,6 +749,10 @@ function count()
             if reverse_play[track] == 0 then
                 position[track] = (position[track] % seqlen[track]) + 1
             else
+                -- fix up resets for reverse play
+                if position[track] == 0 then
+                    position[track] = seqlen[track] + 1
+                end
                 -- Thanks, S.O.! https://stackoverflow.com/a/39740009
                 position[track] = ((position[track] - 1) + 1 * seqlen[track] - 1)
                                   % seqlen[track] + 1


### PR DESCRIPTION
Playing around today with retrograde canon scenarios, and realized while resetting that reverse-play sequence resets are off-by-one. Fixed.

@millxing; I'm not convinced that this isn't a hack, but it works quite nicely, and I don't think that it's necessarily in the wrong place :grin: 