### PR TITLE
Add grid rotation

### DIFF
--- a/quence.lua
+++ b/quence.lua
@@ -90,6 +90,7 @@ local grid_device = grid.connect()
 local midi_device = midi.connect()
 
 function init()
+    grid_device:rotation(0)
     opening_animation()
     math.randomseed(os.time())
 
@@ -191,6 +192,23 @@ function init()
         end,
     }
     ]]--
+    params:add{
+        type = 'option',
+        id = 'rotation',
+        name = 'grid rotation',
+        -- really doesn't make sense to offer all four options here
+        options = {'0', '180'},
+        default = 1,
+        action = function(value)
+            -- hack
+            if value == 1 then
+                value = 0
+            end
+            -- grid API expects [0-3]
+            grid_device:rotation(value)
+            grid_redraw()
+        end,
+    }
 
     -- clock settings
     local clk_midi


### PR DESCRIPTION
as $subject.

I drew part of my grid case flipped :headdesk: - fortunately it worked out fine, but now I need to open PRs to include a grid rotation option in all of my favorite scripts ;p

Thanks to okyeron's grid_test, this was super-easy.

@millxing; If you don't like where the option ends up in the list, I can definitely move it.