### PR TITLE
Fix resets for reverse-play tracks on seq length change

### DIFF
--- a/quence.lua
+++ b/quence.lua
@@ -491,7 +491,11 @@ function grid_device.key(x, y, z)
                     seqlen[track] = 16
                 end
             end
-            position[track] = 0
+            if reverse_play[track] == 0 then
+                position[track] = 0
+            else
+                position[track] = seqlen[track] + 1
+            end
             press = coord
         end
 


### PR DESCRIPTION
Reverse-play tracks were being reset to '0' instead of `seqlen[track] + 1`