### PR TITLE
Fix `crow` keyword in luacheckrc for now

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -23,6 +23,7 @@ stds.quence = {
 stds.norns = {
     globals = {
         'cleanup',
+        'crow',
         'enc',
         'engine',
         'grid',


### PR DESCRIPTION
Eventually we should verify that all norns keywords are in .luacheckrc